### PR TITLE
Improve Face "reporting": recon, wait, sleep

### DIFF
--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -155,7 +155,6 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         if self._epoch.inactive_for >= max_inactive:
             recon_time *= recon_mul
 
-        self._view.set('channel', '*')
         self._current_channel = None
 
         if not channels:
@@ -170,7 +169,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
             except Exception as e:
                 logging.exception("Error while setting wifi.recon.channels (%s)", e)
 
-        self.wait_for(recon_time, sleeping=False)
+        self.set_conducting_recon(recon_time)
 
     def set_access_points(self, aps):
         self._access_points = aps
@@ -508,7 +507,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
                 logging.info("waiting for %ds on channel %d ...", wait, self._current_channel)
             else:
                 logging.debug("waiting for %ds on channel %d ...", wait, self._current_channel)
-            self.wait_for(wait)
+            self.set_observing_channel(wait)
 
     def set_channel(self, channel, verbose=True):
         if self.is_stale():

--- a/pwnagotchi/automata.py
+++ b/pwnagotchi/automata.py
@@ -94,10 +94,23 @@ class Automata(object):
         self._view.on_rebooting()
         plugins.on('rebooting', self)
 
-    def wait_for(self, t, sleeping=True):
-        plugins.on('sleep' if sleeping else 'wait', self, t)
-        self._view.wait(t, sleeping)
+    def sleep_for(self, t):
+        plugins.on('sleep', self, t)
+        self._view.sleep(t)
         self._epoch.track(sleep=True, inc=t)
+
+    def wait_for(self, t):
+        plugins.on('wait', self, t)
+        self._view.wait(t)
+        self._epoch.track(sleep=True, inc=t)
+
+    def set_observing_channel(self, t):
+        self.sleep_for(t)
+
+    def set_conducting_recon(self, recon_time):
+        plugins.on('wait', self, recon_time)
+        self._view.on_recon(recon_time)
+        self._epoch.track(sleep=True, inc=recon_time)
 
     def is_stale(self):
         return self._epoch.num_missed > self._config['personality']['max_misses_for_recon']

--- a/pwnagotchi/automata.py
+++ b/pwnagotchi/automata.py
@@ -105,10 +105,12 @@ class Automata(object):
         self._epoch.track(sleep=True, inc=t)
 
     def set_observing_channel(self, t):
-        self.sleep_for(t)
+        plugins.on('sleep', self, t)    # 'sleep' for backward compatibility
+        self._view.on_listening(t)
+        self._epoch.track(sleep=True, inc=t)
 
     def set_conducting_recon(self, recon_time):
-        plugins.on('wait', self, recon_time)
+        plugins.on('wait', self, recon_time)    # 'wait' for backward compatibility
         self._view.on_recon(recon_time)
         self._epoch.track(sleep=True, inc=recon_time)
 

--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -263,37 +263,19 @@ class View(object):
         self.set('status', self._voice.on_reading_logs(lines_so_far))
         self.update()
 
-    def wait(self, secs, sleeping=True):
-        was_normal = self.is_normal()
-        part = secs / 10.0
+    def sleep(self, secs):
+        self.animate(secs, self._sleeping_face)
 
-        for step in range(0, 10):
-            # if we weren't in a normal state before going
-            # to sleep, keep that face and status on for
-            # a while, otherwise the sleep animation will
-            # always override any minor state change before it
-            if was_normal or step > 5:
-                if sleeping:
-                    if secs > 1:
-                        self.set('face', faces.SLEEP)
-                        self.set('status', self._voice.on_napping(int(secs)))
-
-                    else:
-                        self.set('face', faces.SLEEP2)
-                        self.set('status', self._voice.on_awakening())
-                else:
-                    self.set('status', self._voice.on_waiting(int(secs)))
-
-                    good_mood = self._agent.in_good_mood()
-                    if step % 2 == 0:
-                        self.set('face', faces.LOOK_R_HAPPY if good_mood else faces.LOOK_R)
-                    else:
-                        self.set('face', faces.LOOK_L_HAPPY if good_mood else faces.LOOK_L)
-
-            time.sleep(part)
-            secs -= part
-
-        self.on_normal()
+    def wait(self, secs, get_voice=None):
+        def _waiting_face_closure(was_normal, step, secs_remaining):
+            if get_voice != None:
+                waiting_voice = get_voice
+            else:
+                # use generic waiting voice if not specified
+                waiting_voice = self._voice.on_waiting
+            return self._waiting_face(was_normal, step, secs_remaining,
+                                                 waiting_voice)
+        self.animate(secs, _waiting_face_closure)
 
     def on_shutdown(self):
         self.set('face', faces.SLEEP)
@@ -330,6 +312,10 @@ class View(object):
         self.set('face', faces.EXCITED)
         self.set('status', self._voice.on_excited())
         self.update()
+
+    def on_recon(self, t):
+        self.set('channel', '*')
+        self.wait(t, self._voice.on_recon)
 
     def on_assoc(self, ap):
         self.set('face', faces.INTENSE)
@@ -381,6 +367,39 @@ class View(object):
         self.set('face', faces.DEBUG)
         self.set('status', self._voice.custom(text))
         self.update()
+
+    def _waiting_face(self, was_normal, step, secs_remaining, get_voice):
+        self.set('status', get_voice(int(secs_remaining)))
+        good_mood = self._agent.in_good_mood()
+        if step % 2 == 0:
+            self.set('face', faces.LOOK_R_HAPPY if good_mood else faces.LOOK_R)
+        else:
+            self.set('face', faces.LOOK_L_HAPPY if good_mood else faces.LOOK_L)
+
+    def _sleeping_face(self, was_normal, step, secs_remaining):
+        if secs_remaining > 1:
+            self.set('face', faces.SLEEP)
+            self.set('status', self._voice.on_napping(int(secs_remaining)))
+        else:
+            self.set('face', faces.SLEEP2)
+            self.set('status', self._voice.on_awakening())
+
+    def animate(self, secs, what):
+        was_normal = self.is_normal()
+        part = secs / 10.0
+
+        for step in range(0, 10):
+            # if we weren't in a normal state before going
+            # to sleep, keep that face and status on for
+            # a while, otherwise the sleep animation will
+            # always override any minor state change before it
+            if was_normal or step > 5:
+                what(was_normal, step, secs)
+
+            time.sleep(part)
+            secs -= part
+
+        self.on_normal()
 
     def update(self, force=False, new_data={}):
         for key, val in new_data.items():

--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -317,6 +317,9 @@ class View(object):
         self.set('channel', '*')
         self.wait(t, self._voice.on_recon)
 
+    def on_listening(self, t):
+        self.wait(t, self._voice.on_listening)
+
     def on_assoc(self, ap):
         self.set('face', faces.INTENSE)
         self.set('status', self._voice.on_assoc(ap))

--- a/pwnagotchi/voice.py
+++ b/pwnagotchi/voice.py
@@ -131,8 +131,17 @@ class Voice:
     def on_waiting(self, secs):
         return random.choice([
             self._('Waiting for {secs}s ...').format(secs=secs),
-            '...',
-            self._('Looking around ({secs}s)').format(secs=secs)])
+            '...'])
+
+    def on_recon(self, secs):
+        return random.choice([
+            self._('Looking around ({secs}s)').format(secs=secs),
+            self._('Hello? Anybody there? ({secs}s)').format(secs=secs)])
+
+    def on_listening(self, secs):
+        return random.choice([
+            self._('I\'m listening... ({secs}s)').format(secs=secs),
+            self._('Observing... ({secs}s)').format(secs=secs)])
 
     def on_assoc(self, ap):
         ssid, bssid = ap['hostname'], ap['mac']


### PR DESCRIPTION
This PR improves face UX, and separation of concerns  in Agent by:

* introducing additional Automata state and View statuses for
  * recon (channel hopping)
  * channel listening phase
* internally distinguishing wait and sleep states: 
  * wait as for "active" waiting for something to happen, useful activity
  * sleep as for sleep in throttling
 
Other changes:
* refactoring of the face animation with different voice per frame