### PR TITLE
Bettercap reconnection exceptions recovery

### DIFF
--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -16,7 +16,7 @@ from pwnagotchi.identity import KeyPair
 from pwnagotchi.ui.web.server import Server
 from pwnagotchi.automata import Automata
 from pwnagotchi.log import LastSession
-from pwnagotchi.bettercap import Client, BettercapException
+from pwnagotchi.bettercap import Client, BettercapConnectionError, BettercapError
 from pwnagotchi.mesh.utils import AsyncAdvertiser
 from pwnagotchi.ai.train import AsyncTrainer
 
@@ -70,8 +70,6 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         return self._supported_channels
 
     def setup_events(self):
-        logging.info("connecting to %s ...", self.url)
-
         for tag in self._config['bettercap']['silence']:
             try:
                 self.run('events.ignore %s' % tag, verbose_errors=False)
@@ -131,7 +129,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
                 _s = self.session()
                 return
             except Exception:
-                logging.info("waiting for bettercap API to be available ...")
+                logging.info("waiting for bettercap API to become available ...")
                 time.sleep(1)
 
     def start(self):
@@ -188,7 +186,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
                     continue
                 else:
                     aps.append(ap)
-        except BettercapException as e:
+        except BettercapConnectionError as e:
             raise e
         except Exception as e:
             # consider exceptions other than from bettercap safe to ignore
@@ -390,9 +388,9 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
             try:
                 loop.create_task(self.start_websocket(self._on_event))
                 loop.run_forever()
-                logging.debug("[agent:_event_poller] loop loop loop")
+                logging.info("[agent:_event_poller] loop loop loop")
             except Exception as ex:
-                logging.debug("[agent:_event_poller] Error while polling via websocket (%s)", ex)
+                logging.error("[agent:_event_poller] Error while polling via websocket (%s)", ex)
 
     def start_event_polling(self):
         # start a thread and pass in the mainloop
@@ -462,7 +460,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
                              ap['hostname'], ap['mac'], ap['vendor'], ap['channel'], len(ap['clients']), ap['rssi'])
                 self.run('wifi.assoc %s' % ap['mac'])
                 self._epoch.track(assoc=True)
-            except Exception as e:
+            except BettercapError as e:
                 self._on_error(ap['mac'], e)
 
             plugins.on('association', self, ap)
@@ -482,7 +480,7 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
                              ap['rssi'])
                 self.run('wifi.deauth %s' % sta['mac'])
                 self._epoch.track(deauth=True)
-            except Exception as e:
+            except BettercapError as e:
                 self._on_error(sta['mac'], e)
 
             plugins.on('deauthentication', self, ap, sta)

--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -16,7 +16,7 @@ from pwnagotchi.identity import KeyPair
 from pwnagotchi.ui.web.server import Server
 from pwnagotchi.automata import Automata
 from pwnagotchi.log import LastSession
-from pwnagotchi.bettercap import Client
+from pwnagotchi.bettercap import Client, BettercapException
 from pwnagotchi.mesh.utils import AsyncAdvertiser
 from pwnagotchi.ai.train import AsyncTrainer
 
@@ -162,12 +162,10 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
             # Enable channel hopping on all supported channels.
             self.run('wifi.recon.channel clear')
         else:
-            logging.debug("RECON %ds ON CHANNELS %s", recon_time, ','.join(map(str, channels)))
-            try:
-                # Comma separated list of channels to hop on
-                self.run('wifi.recon.channel %s' % ','.join(map(str, channels)))
-            except Exception as e:
-                logging.exception("Error while setting wifi.recon.channels (%s)", e)
+            # Comma separated list of channels to hop on
+            channel_list = ','.join(map(str, channels))
+            logging.debug("RECON %ds ON CHANNELS %s", recon_time, channel_list)
+            self.run('wifi.recon.channel %s' % channel_list)
 
         self.set_conducting_recon(recon_time)
 
@@ -190,7 +188,10 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
                     continue
                 else:
                     aps.append(ap)
+        except BettercapException as e:
+            raise e
         except Exception as e:
+            # consider exceptions other than from bettercap safe to ignore
             logging.exception("Error while getting access points (%s)", e)
 
         aps.sort(key=lambda ap: ap['channel'])
@@ -533,3 +534,4 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
 
         except Exception as e:
             logging.error("Error while setting channel (%s)", e)
+            raise e

--- a/pwnagotchi/bettercap.py
+++ b/pwnagotchi/bettercap.py
@@ -10,7 +10,6 @@ from requests.packages.urllib3.util.retry import Retry
 
 import pwnagotchi
 
-requests.adapters.DEFAULT_RETRIES = 5  # increase retries number
 
 ping_timeout = 180
 ping_interval = 15
@@ -43,7 +42,14 @@ class Client(object):
         self.password = password
         self.url = "%s://%s:%d/api" % (scheme, hostname, port)
         self.websocket = "ws://%s:%s@%s:%d/api" % (username, password, hostname, port)
-        self.auth = HTTPBasicAuth(username, password)
+
+        retry = Retry(total=5, backoff_factor=min_sleep, backoff_max=max_sleep, backoff_jitter=0.5)
+        adapter = HTTPAdapter(max_retries=retry)
+
+        self.http = requests.Session()
+        self.http.auth = HTTPBasicAuth(username, password)
+        self.http.mount('http://', adapter)
+        self.http.mount('https://', adapter)
 
     # session takes optional argument to pull a sub-dictionary
     #  ex.: "session/wifi", "session/ble"

--- a/pwnagotchi/bettercap.py
+++ b/pwnagotchi/bettercap.py
@@ -10,6 +10,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 import pwnagotchi
 
+logger = logging.getLogger(__name__)
 
 ping_timeout = 180
 ping_interval = 15
@@ -28,11 +29,11 @@ def decode(r, verbose_errors=True):
         return r.json()
     except Exception as e:
         if r.status_code == 200:
-            logging.error("error while decoding json: error='%s' resp='%s'" % (e, r.text))
+            logger.error("error while decoding json: error='%s' resp='%s'" % (e, r.text))
         else:
             err = "error %d: %s" % (r.status_code, r.text.strip())
             if verbose_errors:
-                logging.info(err)
+                logger.info(err)
             raise BettercapError(err)
         return r.text
 
@@ -71,21 +72,22 @@ class Client(object):
         # do we need this outer loop to manage the initial connection?
         while True:
             try:
-                logging.info("[bettercap] creating new websocket...")
+                logger.debug("creating new websocket...")
                 async for ws in websockets.connect(s, ping_interval=ping_interval, ping_timeout=ping_timeout,
                                                 max_queue=max_queue):
+                    logger.info("connected to websocket")
                     try:
                         async for msg in ws:
                             try:
                                 await consumer(msg)
                             except Exception as ex:
-                                logging.debug("[bettercap] error while parsing event (%s)", ex)
+                                logger.debug("error while parsing event (%s)", ex)
                     except websockets.ConnectionClosedError:
                         continue
             except ConnectionRefusedError:
                 sleep_time = min_sleep + max_sleep*random.random()
-                logging.warning('[bettercap] nobody seems to be listening at the bettercap endpoint...')
-                logging.warning('[bettercap] retrying connection in {} sec'.format(sleep_time))
+                logger.warning('nobody seems to be listening at the bettercap endpoint')
+                logger.warning('retrying connection in {} sec'.format(sleep_time))
                 await asyncio.sleep(sleep_time)
                 continue
             except Exception as e:

--- a/pwnagotchi/bettercap.py
+++ b/pwnagotchi/bettercap.py
@@ -18,6 +18,10 @@ max_queue = 10000
 min_sleep = 0.5
 max_sleep = 5.0
 
+websockets.connect.BACKOFF_INITIAL_DELAY = min_sleep
+websockets.connect.BACKOFF_MIN_DELAY = min_sleep
+websockets.connect.BACKOFF_MAX_DELAY = max_sleep
+
 
 def decode(r, verbose_errors=True):
     try:
@@ -63,46 +67,21 @@ class Client(object):
     async def start_websocket(self, consumer):
         s = "%s/events" % self.websocket
 
-        # More modern version of the approach below
-        # logging.info("Creating new websocket...")
-        # async for ws in websockets.connect(s):
-        #     try:
-        #         async for msg in ws:
-        #             try:
-        #                 await consumer(msg)
-        #             except Exception as ex:
-        #                     logging.debug("Error while parsing event (%s)", ex)
-        #     except websockets.exceptions.ConnectionClosedError:
-        #         sleep_time = max_sleep*random.random()
-        #         logging.warning('Retrying websocket connection in {} sec'.format(sleep_time))
-        #         await asyncio.sleep(sleep_time)
-        #         continue
-
         # restarted every time the connection fails
+        # do we need this outer loop to manage the initial connection?
         while True:
-            logging.info("[bettercap] creating new websocket...")
             try:
-                async with websockets.connect(s, ping_interval=ping_interval, ping_timeout=ping_timeout,
-                                              max_queue=max_queue) as ws:
-                    # listener loop
-                    while True:
-                        try:
-                            async for msg in ws:
-                                try:
-                                    await consumer(msg)
-                                except Exception as ex:
-                                    logging.debug("[bettercap] error while parsing event (%s)", ex)
-                        except websockets.ConnectionClosedError:
+                logging.info("[bettercap] creating new websocket...")
+                async for ws in websockets.connect(s, ping_interval=ping_interval, ping_timeout=ping_timeout,
+                                                max_queue=max_queue):
+                    try:
+                        async for msg in ws:
                             try:
-                                pong = await ws.ping()
-                                await asyncio.wait_for(pong, timeout=ping_timeout)
-                                logging.warning('[bettercap] ping OK, keeping connection alive...')
-                                continue
-                            except:
-                                sleep_time = min_sleep + max_sleep*random.random()
-                                logging.warning('[bettercap] ping error - retrying connection in {} sec'.format(sleep_time))
-                                await asyncio.sleep(sleep_time)
-                                break
+                                await consumer(msg)
+                            except Exception as ex:
+                                logging.debug("[bettercap] error while parsing event (%s)", ex)
+                    except websockets.ConnectionClosedError:
+                        continue
             except ConnectionRefusedError:
                 sleep_time = min_sleep + max_sleep*random.random()
                 logging.warning('[bettercap] nobody seems to be listening at the bettercap endpoint...')

--- a/pwnagotchi/bettercap.py
+++ b/pwnagotchi/bettercap.py
@@ -5,7 +5,8 @@ import asyncio
 import random
 
 from requests.auth import HTTPBasicAuth
-from time import sleep
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 import pwnagotchi
 
@@ -47,8 +48,11 @@ class Client(object):
     # session takes optional argument to pull a sub-dictionary
     #  ex.: "session/wifi", "session/ble"
     def session(self, sess="session"):
-        r = requests.get("%s/%s" % (self.url, sess), auth=self.auth)
-        return decode(r)
+        try:
+            r = self.http.get("%s/%s" % (self.url, sess))
+            return decode(r)
+        except Exception as e:
+            raise BettercapException("Error getting session %s", sess) from e
 
     async def start_websocket(self, consumer):
         s = "%s/events" % self.websocket
@@ -102,17 +106,15 @@ class Client(object):
             except OSError:
                 logging.warning('connection to the bettercap endpoint failed...')
                 pwnagotchi.restart("AUTO")
+                # os.system("service bettercap restart")
+                # time.sleep(1)
 
     def run(self, command, verbose_errors=True):
-        while True:
-            try:
-                r = requests.post("%s/session" % self.url, auth=self.auth, json={'cmd': command})
-            except requests.exceptions.ConnectionError as e:
-                sleep_time = min_sleep + max_sleep*random.random()
-                logging.warning("[bettercap] can't run my request... connection to the bettercap endpoint failed...")
-                logging.warning('[bettercap] retrying run in {} sec'.format(sleep_time))
-                sleep(sleep_time)
-            else:
-                break
+        try:
+            r = self.http.post("%s/session" % self.url, json={'cmd': command})
+            return decode(r, verbose_errors=verbose_errors)
+        except Exception as e:
+            raise BettercapException("Error while executing command %s", command) from e
 
-        return decode(r, verbose_errors=verbose_errors)
+class BettercapException(Exception):
+    pass

--- a/pwnagotchi/bettercap.py
+++ b/pwnagotchi/bettercap.py
@@ -88,11 +88,11 @@ class Client(object):
                 logging.warning('[bettercap] retrying connection in {} sec'.format(sleep_time))
                 await asyncio.sleep(sleep_time)
                 continue
-            except OSError:
-                logging.warning('connection to the bettercap endpoint failed...')
-                pwnagotchi.restart("AUTO")
-                # os.system("service bettercap restart")
-                # time.sleep(1)
+            except Exception as e:
+                logger.error('connection to the websocket endpoint failed')
+                logger.error('hoping that the error will be detected via `session` fail and bettercap will be restarted')
+                # TODO: recovery procedure.
+                # can't just reraise an exception because we're not in the main thread
 
     def run(self, command, verbose_errors=True):
         try:

--- a/pwnagotchi/bettercap.py
+++ b/pwnagotchi/bettercap.py
@@ -33,7 +33,7 @@ def decode(r, verbose_errors=True):
             err = "error %d: %s" % (r.status_code, r.text.strip())
             if verbose_errors:
                 logging.info(err)
-            raise Exception(err)
+            raise BettercapError(err)
         return r.text
 
 
@@ -62,7 +62,7 @@ class Client(object):
             r = self.http.get("%s/%s" % (self.url, sess))
             return decode(r)
         except Exception as e:
-            raise BettercapException("Error getting session %s", sess) from e
+            raise BettercapConnectionError(f"Error getting session {sess}") from e
 
     async def start_websocket(self, consumer):
         s = "%s/events" % self.websocket
@@ -98,8 +98,12 @@ class Client(object):
         try:
             r = self.http.post("%s/session" % self.url, json={'cmd': command})
             return decode(r, verbose_errors=verbose_errors)
+        except BettercapError as e:
+            raise e
         except Exception as e:
-            raise BettercapException("Error while executing command %s", command) from e
+            raise BettercapConnectionError(f"Error while executing command '{command}'") from e
 
-class BettercapException(Exception):
+class BettercapConnectionError(Exception):
+    pass
+class BettercapError(Exception):
     pass

--- a/pwnagotchi/cli.py
+++ b/pwnagotchi/cli.py
@@ -101,10 +101,15 @@ def pwnagotchi_cli():
             except BettercapConnectionError as e:
                 logging.exception(f"Unrecovered bettercap exception: {e}")
                 
+                # agent._view.sleep(5) # this does time.sleep(5)
+                import pwnagotchi.ui.faces as faces
+                agent._view.update(force=True, new_data={"status": "Restarting bettercap",
+                                                         "face": faces.DEBUG})
                 logging.warning("Attempting to restart bettercap")
+
                 os.system("service bettercap restart")
-                time.sleep(1)
                 # reconfigure bettercap?
+                time.sleep(5)
 
             except Exception as e:
                 if str(e).find("wifi.interface not set") > 0:

--- a/pwnagotchi/cli.py
+++ b/pwnagotchi/cli.py
@@ -47,7 +47,7 @@ def pwnagotchi_cli():
                 plugins.on('internet_available', agent)
 
     def do_auto_mode(agent: Agent):
-        from pwnagotchi.agent import BettercapException
+        from pwnagotchi.agent import BettercapConnectionError
 
         logging.info("entering auto mode ...")
 
@@ -97,9 +97,10 @@ def pwnagotchi_cli():
 
                 if grid.is_connected():
                     plugins.on('internet_available', agent)
-                    
-            except BettercapException as e:
-                logging.exception("Unrecovered bettercap exception (%s)", e)
+
+            except BettercapConnectionError as e:
+                logging.exception(f"Unrecovered bettercap exception: {e}")
+                
                 logging.warning("Attempting to restart bettercap")
                 os.system("service bettercap restart")
                 time.sleep(1)

--- a/pwnagotchi/cli.py
+++ b/pwnagotchi/cli.py
@@ -47,6 +47,8 @@ def pwnagotchi_cli():
                 plugins.on('internet_available', agent)
 
     def do_auto_mode(agent: Agent):
+        from pwnagotchi.agent import BettercapException
+
         logging.info("entering auto mode ...")
 
         agent.mode = 'auto'
@@ -95,6 +97,13 @@ def pwnagotchi_cli():
 
                 if grid.is_connected():
                     plugins.on('internet_available', agent)
+                    
+            except BettercapException as e:
+                logging.exception("Unrecovered bettercap exception (%s)", e)
+                logging.warning("Attempting to restart bettercap")
+                os.system("service bettercap restart")
+                time.sleep(1)
+                # reconfigure bettercap?
 
             except Exception as e:
                 if str(e).find("wifi.interface not set") > 0:


### PR DESCRIPTION
This is an ongoing project on improving Bettercap module resilience and error handling in its current **stable state**. Though not technically perfect in all aspects, this PR provides significant improvements affecting stability of Pwnagotchi in general, via:

* Simplifying reconnection logic by offsetting this functionality to `urllib`, which is already used internally by `requests`
* Handling BettercapError – errors as returned by Bettercap itself
* Handling BettercapConnectionError – errors caused by problems connecting to bettercap, likely caused by bettercap being down or needing restart