### PR TITLE
fix_services: Avoid double-triggering, refactor plugin

### DIFF
--- a/pwnagotchi/__init__.py
+++ b/pwnagotchi/__init__.py
@@ -136,7 +136,10 @@ def restart(mode):
 
     os.system("service bettercap restart")
     time.sleep(1)
-    os.system("service pwnagotchi restart")
+    # rely on a service manager (like systemd)
+    # to restart us according to restart policy
+    logging.critical("Exiting to be restarted...")
+    os._exit(2) # kill all threads
 
 
 def reboot(mode=None):

--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -106,7 +106,7 @@ class FixServices(plugins.Plugin):
                 subprocess.check_output("monstart", shell=True)
                 display.set('status', 'Wifi channel stuck. Restarting recon.')
                 display.update(force=True)
-                pwnagotchi.restart("AUTO")
+                agent._restart("AUTO")
 
             # Look for pattern 2
             elif len(self.pattern2.findall(other_last_lines)) >= 5:
@@ -163,8 +163,8 @@ class FixServices(plugins.Plugin):
                 if hasattr(agent, 'view'):
                     display.set('status', 'Restarting pwnagotchi!')
                     display.update(force=True)
-                os.system("systemctl restart bettercap")
-                pwnagotchi.restart("AUTO")
+                logging.error('[Fix_Services] restarting bettercap and pwnagotchi')
+                agent._restart("AUTO")
 
             # Look for pattern 6
             elif len(self.pattern6.findall(other_other_last_lines)) >= 1:
@@ -172,8 +172,8 @@ class FixServices(plugins.Plugin):
                 if hasattr(agent, 'view'):
                     display.set('status', 'Restarting pwnagotchi!')
                     display.update(force=True)
-                os.system("systemctl restart bettercap")
-                pwnagotchi.restart("AUTO")
+                logging.error('[Fix_Services] restarting bettercap and pwnagotchi')
+                agent._restart("AUTO")
 
             # Look for pattern 7
             elif len(self.pattern7.findall(other_other_last_lines)) >= 1:
@@ -338,7 +338,7 @@ class FixServices(plugins.Plugin):
                         print(" wlan0mon didn't make it. trying again")
                 else:
                     logging.debug("[Fix_Services] wlan0mon loading failed, no choice but to reboot ..")
-                    pwnagotchi.reboot()
+                    agent._reboot()
 
             # exited the loop, so hopefully it loaded
             if tries < 3:
@@ -373,7 +373,7 @@ class FixServices(plugins.Plugin):
 
             except Exception as err:
                 logging.error("[Fix_Services wifi.recon on] %s" % repr(err))
-                pwnagotchi.reboot()
+                agent._reboot()
 
     # called to setup the ui elements
     def on_ui_setup(self, ui):

--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -3,7 +3,6 @@ import re
 import subprocess
 import time
 import random
-from io import TextIOWrapper
 import os
 
 import pwnagotchi
@@ -52,8 +51,9 @@ class FixServices(plugins.Plugin):
         logger.info("plugin loaded.")
 
     def on_ready(self, agent: Agent):
-        last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
-                                                                 stdout=subprocess.PIPE).stdout))[-10:])
+        last_lines = ''.join(list(subprocess.Popen(['journalctl', '-n10', '-k'],
+                                                   stdout=subprocess.PIPE).stdout,
+                                  text=True)[-10:])
         try:
             cmd_output = subprocess.check_output("ip link show wlan0mon", shell=True)
             logger.debug("[ip link show wlan0mon]: %s" % repr(cmd_output))
@@ -82,13 +82,16 @@ class FixServices(plugins.Plugin):
                                                 self._tryTurningItOffAndOnAgain)
 
     def on_epoch(self, agent: Agent, epoch: Epoch, epoch_data):
-        kernel_log = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
-                                                                 stdout=subprocess.PIPE).stdout))[-10:])
-        sys_log = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10'],
-                                                                       stdout=subprocess.PIPE).stdout))[-10:])
+        kernel_log = ''.join(list(subprocess.Popen(['journalctl', '-n10', '-k'],
+                                                   stdout=subprocess.PIPE).stdout,
+                                  text=True)[-10:])
+        sys_log = ''.join(list(subprocess.Popen(['journalctl', '-n10'],
+                                                stdout=subprocess.PIPE).stdout,
+                               text=True)[-10:])
         pwnagotchi_log = ''.join(
-            list(TextIOWrapper(subprocess.Popen(['tail', '-n10', '/etc/pwnagotchi/log/pwnagotchi.log'],
-                                                stdout=subprocess.PIPE).stdout))[-10:])
+            list(subprocess.Popen(['tail', '-n10', '/etc/pwnagotchi/log/pwnagotchi.log'],
+                                  stdout=subprocess.PIPE).stdout,
+                 text=True)[-10:])
         # don't check if we ran a reset recently
         logger.debug("**** epoch")
         if time.time() - self.LASTTRY > 180:

--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -19,6 +19,8 @@ from pwnagotchi.ui.components import Text
 from pwnagotchi.ui.view import BLACK
 import pwnagotchi.ui.fonts as fonts
 
+logger = logging.getLogger(__name__)
+
 
 class FixServices(plugins.Plugin):
     __author__ = 'jayofelony'
@@ -47,35 +49,35 @@ class FixServices(plugins.Plugin):
         """
         Gets called when the plugin gets loaded
         """
-        logging.info("[Fix_Services] plugin loaded.")
+        logger.info("plugin loaded.")
 
     def on_ready(self, agent: Agent):
         last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
                                                                  stdout=subprocess.PIPE).stdout))[-10:])
         try:
             cmd_output = subprocess.check_output("ip link show wlan0mon", shell=True)
-            logging.debug("[Fix_Services ip link show wlan0mon]: %s" % repr(cmd_output))
+            logger.debug("[ip link show wlan0mon]: %s" % repr(cmd_output))
             if ",UP," in str(cmd_output):
-                logging.debug("wlan0mon is up.")
+                logger.debug("wlan0mon is up.")
 
         except Exception as err:
-            logging.error("[Fix_Services ip link show wlan0mon]: %s" % repr(err))
+            logger.error("[ip link show wlan0mon]: %s" % repr(err))
             try:
                 self._tryTurningItOffAndOnAgain(agent)
             except Exception as err:
-                logging.error("[Fix_Services OffNOn]: %s" % repr(err))
+                logger.error("[OffNOn]: %s" % repr(err))
 
     # bettercap sys_log event
     # search syslog events for the brcmf channel fail, and reset when it shows up
     # apparently this only gets messages from bettercap going to syslog, not from syslog
     def on_bcap_sys_log(self, agent: Agent, event):
         if re.search('wifi error while hopping to channel', event['data']['Message']):
-            logging.debug("[Fix_Services]SYSLOG MATCH: %s" % event['data']['Message'])
-            logging.debug("[Fix_Services]**** restarting wifi.recon")
+            logger.debug("SYSLOG MATCH: %s" % event['data']['Message'])
+            logger.debug("**** restarting wifi.recon")
             try:
                 result = agent.run("wifi.recon off; wifi.recon on")
                 if result["success"]:
-                    logging.debug("[Fix_Services] wifi.recon flip: success!")
+                    logger.debug("wifi.recon flip: success!")
                     if hasattr(agent, 'view'):
                         display = agent.view()
                         if display:
@@ -83,10 +85,10 @@ class FixServices(plugins.Plugin):
                     else:
                         print("Wifi recon flipped")
                 else:
-                    logging.warning("[Fix_Services] wifi.recon flip: FAILED: %s" % repr(result))
+                    logger.warning("wifi.recon flip: FAILED: %s" % repr(result))
                     self._tryTurningItOffAndOnAgain(agent)
             except Exception as err:
-                logging.error("[Fix_Services]SYSLOG wifi.recon flip fail: %s" % err)
+                logger.error("SYSLOG wifi.recon flip fail: %s" % err)
                 self._tryTurningItOffAndOnAgain(agent)
 
     def on_epoch(self, agent: Agent, epoch: Epoch, epoch_data):
@@ -98,7 +100,7 @@ class FixServices(plugins.Plugin):
             list(TextIOWrapper(subprocess.Popen(['tail', '-n10', '/etc/pwnagotchi/log/pwnagotchi.log'],
                                                 stdout=subprocess.PIPE).stdout))[-10:])
         # don't check if we ran a reset recently
-        logging.debug("[Fix_Services]**** epoch")
+        logger.debug("**** epoch")
         if time.time() - self.LASTTRY > 180:
             # get last 10 lines
             if hasattr(agent, 'view'):
@@ -106,7 +108,7 @@ class FixServices(plugins.Plugin):
             else:
                 display = None
 
-            logging.debug("[Fix_Services]**** checking")
+            logger.debug("**** checking")
             if len(self.pattern.findall(last_lines)) >= 1:
                 self.logPrintView("error", "Monitor interface error. Reloading kernel modules, restarting.",
                                     display, {"status": "Monitor interface error. Reloading kernel modules, restarting.",
@@ -118,7 +120,7 @@ class FixServices(plugins.Plugin):
 
             # Look for pattern 2
             elif len(self.pattern2.findall(other_last_lines)) >= 5:
-                logging.debug("[Fix_Services]**** Should trigger a reload of the wlan0mon device:\n%s" % last_lines)
+                logger.debug("**** Should trigger a reload of the wlan0mon device:\n%s" % last_lines)
                 self.logPrintView("error", "Wifi channel stuck. Restarting recon.",
                                     display, {"status": "Wifi channel stuck. Restarting recon.",
                                               "face": faces.COOL},
@@ -143,36 +145,36 @@ class FixServices(plugins.Plugin):
 
             # Look for pattern 5
             elif len(self.pattern5.findall(other_other_last_lines)) >= 1:
-                logging.debug("[Fix_Services] Bettercap has crashed!")
+                logger.debug("Bettercap has crashed!")
                 self._remedy_pwnagotchi_restart(agent, display)
 
             # Look for pattern 6
             elif len(self.pattern6.findall(other_other_last_lines)) >= 1:
-                logging.debug("[Fix_Services] Bettercap has crashed!")
+                logger.debug("Bettercap has crashed!")
                 self._remedy_pwnagotchi_restart(agent, display)
 
             # Look for pattern 7
             elif len(self.pattern7.findall(other_other_last_lines)) >= 1:
-                logging.debug("[Fix_Services] Monitor mode failed!")
+                logger.debug("Monitor mode failed!")
                 self._remedy_bettercap_recon_off_on(agent, display)
             else:
-                logging.debug("logs look good")
+                logger.debug("logs look good")
 
     def _remedy_monstop(self, display: View):
         try:
             cmd_output = subprocess.check_output("monstop", shell=True)
-            self.logPrintView("info", "[Fix_Services] wlan0mon down and deleted: %s" % repr(cmd_output),
+            self.logPrintView("info", "wlan0mon down and deleted: %s" % repr(cmd_output),
                                 display, {"status": "wlan0mon d-d-d-down!", "face": faces.BORED})
         except Exception as nope:
-            logging.error("[Fix_Services delete wlan0mon] %s" % repr(nope))
+            logger.error("[delete wlan0mon] %s" % repr(nope))
 
     def _remedy_monstart(self):
         try:
             # Run the monstart command to restart wlan0mon
             cmd_output = subprocess.check_output("monstart", shell=True)
-            logging.debug("[Fix_Services monstart]: %s" % repr(cmd_output))
+            logger.debug("[monstart]: %s" % repr(cmd_output))
         except Exception as err:
-            logging.error("[Fix_Services monstart]: %s" % repr(err))
+            logger.error("[monstart]: %s" % repr(err))
 
     def _remedy_pwnagotchi_restart(self, agent: Agent, display: View):
         self.logPrintView("error", "restarting bettercap and pwnagotchi",
@@ -185,27 +187,23 @@ class FixServices(plugins.Plugin):
         try:
             result = agent.run("wifi.recon off; wifi.recon on")
             if result["success"]:
-                logging.debug("[Fix_Services] wifi.recon flip: success!")
+                logger.debug("wifi.recon flip: success!")
                 self.logPrintView("debug", "wifi.recon flip: success!",
                                     display, {"status": "Wifi recon flipped!",
                                               "face": faces.COOL},
                                     True)
             else:
-                logging.warning("[Fix_Services] wifi.recon flip: FAILED: %s" % repr(result))
+                logger.warning("wifi.recon flip: FAILED: %s" % repr(result))
 
         except Exception as err:
-            logging.error("[Fix_Services wifi.recon flip] %s" % repr(err))
+            logger.error("[wifi.recon flip] %s" % repr(err))
 
-    def logPrintView(self, level, message, ui=None, displayData=None, force=True):
+    def logPrintView(self, level: str, message, ui=None, displayData=None, force=True):
         try:
-            if level == "error":
-                logging.error(message)
-            elif level == "warning":
-                logging.warning(message)
-            elif level == "debug":
-                logging.debug(message)
-            else:
-                logging.debug(message)
+            lvl = logger.getLevelNamesMapping.get(level.upper())
+            if lvl is None:
+                lvl = logger.ERROR
+            logger.log(lvl, message)
 
             if ui:
                 ui.update(force=force, new_data=displayData)
@@ -214,13 +212,13 @@ class FixServices(plugins.Plugin):
             else:
                 print("[%s] %s" % (level, message))
         except Exception as err:
-            logging.error("[logPrintView] ERROR %s" % repr(err))
+            logger.error("[logPrintView] ERROR %s" % repr(err))
 
     def _tryTurningItOffAndOnAgain(self, connection):
         # avoid overlapping restarts, but allow it if it's been a while
         # (in case the last attempt failed before resetting "isReloadingMon")
         if self.isReloadingMon and (time.time() - self.LASTTRY) < 180:
-            logging.debug("[Fix_Services] Duplicate attempt ignored")
+            logger.debug("Duplicate attempt ignored")
         else:
             self.isReloadingMon = True
             self.LASTTRY = time.time()
@@ -245,34 +243,34 @@ class FixServices(plugins.Plugin):
             # is it up?
             try:
                 cmd_output = subprocess.check_output("ip link show wlan0mon", shell=True)
-                logging.debug("[Fix_Services ip link show wlan0mon]: %s" % repr(cmd_output))
+                logger.debug("[ip link show wlan0mon]: %s" % repr(cmd_output))
                 if ",UP," in str(cmd_output):
-                    logging.debug("wlan0mon is up. Skip reset?")
+                    logger.debug("wlan0mon is up. Skip reset?")
                     # not reliable, so don't skip just yet
                     # print("wlan0mon is up. Skipping reset.")
                     # self.isReloadingMon = False
                     # return
             except Exception as err:
-                logging.error("[Fix_Services ip link show wlan0mon]: %s" % repr(err))
+                logger.error("[ip link show wlan0mon]: %s" % repr(err))
 
             try:
                 result = connection.run("wifi.recon off")
                 if "success" in result:
-                    self.logPrintView("info", "[Fix_Services] wifi.recon off: %s!" % repr(result),
+                    self.logPrintView("info", "wifi.recon off: %s!" % repr(result),
                                       display, {"status": "Wifi recon paused!", "face": faces.COOL})
                     time.sleep(2)
                 else:
-                    self.logPrintView("warning", "[Fix_Services] wifi.recon off: FAILED: %s" % repr(result),
+                    self.logPrintView("warning", "wifi.recon off: FAILED: %s" % repr(result),
                                       display, {"status": "Recon was busted (probably)",
                                                 "face": random.choice((faces.BROKEN, faces.DEBUG))})
             except Exception as err:
-                logging.error("[Fix_Services wifi.recon off] error  %s" % (repr(err)))
+                logger.error("[wifi.recon off] error  %s" % (repr(err)))
 
-            logging.debug("[Fix_Services] recon paused. Now trying wlan0mon reload")
+            logger.debug("recon paused. Now trying wlan0mon reload")
 
             self._remedy_monstop(display)
 
-            logging.debug("[Fix_Services] Now trying modprobe -r")
+            logger.debug("Now trying modprobe -r")
 
             # Try this sequence 3 times until it is reloaded
             #
@@ -283,7 +281,7 @@ class FixServices(plugins.Plugin):
                 try:
                     # unload the module
                     cmd_output = subprocess.check_output("sudo modprobe -r brcmfmac", shell=True)
-                    self.logPrintView("info", "[Fix_Services] unloaded brcmfmac", display,
+                    self.logPrintView("info", "unloaded brcmfmac", display,
                                       {"status": "Turning it off #%s" % tries, "face": faces.SMART})
 
                     # reload the module
@@ -291,48 +289,46 @@ class FixServices(plugins.Plugin):
                         # reload the brcmfmac kernel module
                         cmd_output = subprocess.check_output("sudo modprobe brcmfmac", shell=True)
 
-                        self.logPrintView("info", "[Fix_Services] reloaded brcmfmac")
+                        self.logPrintView("info", "reloaded brcmfmac")
 
                         # success! now make the mon0
                         try:
                             cmd_output = subprocess.check_output("monstart", shell=True)
-                            self.logPrintView("info", "[Fix_Services interface add wlan0mon worked #%s: %s"
+                            self.logPrintView("info", "[interface add wlan0mon worked #%s: %s"
                                               % (tries, cmd_output))
                             try:
                                 # try accessing mon0 in bettercap
                                 result = connection.run("set wifi.interface wlan0mon")
                                 if "success" in result:
-                                    logging.debug("[Fix_Services set wifi.interface wlan0mon worked!")
+                                    logger.debug("[set wifi.interface wlan0mon worked!")
                                     # stop looping and get back to recon
                                     break
                                 else:
-                                    logging.debug(
-                                        "[Fix_Services set wifi.interfaceface wlan0mon] failed? %s" % repr(result))
+                                    logger.debug(
+                                        "[set wifi.interfaceface wlan0mon] failed? %s" % repr(result))
                             except Exception as err:
-                                logging.debug(
-                                    "[Fix_Services set wifi.interface wlan0mon] except: %s" % repr(err))
+                                logger.debug(
+                                    "[set wifi.interface wlan0mon] except: %s" % repr(err))
                         except Exception as cerr:  #
                             if not display:
                                 print("failed loading wlan0mon attempt #%s: %s" % (tries, repr(cerr)))
                     except Exception as err:  # from modprobe
                         if not display:
                             print("Failed reloading brcmfmac")
-                        logging.error("[Fix_Services] Failed reloading brcmfmac %s" % repr(err))
+                        logger.error("Failed reloading brcmfmac %s" % repr(err))
 
                 except Exception as nope:  # from modprobe -r
                     # fails if already unloaded, so probably fine
-                    logging.error("[Fix_Services #%s modprobe -r] %s" % (tries, repr(nope)))
+                    logger.error("[#%s modprobe -r] %s" % (tries, repr(nope)))
                     if not display:
-                        print("[Fix_Services #%s modprobe -r] %s" % (tries, repr(nope)))
+                        print("[#%s modprobe -r] %s" % (tries, repr(nope)))
                     pass
 
                 tries = tries + 1
                 if tries < 3:
-                    logging.debug("[Fix_Services] wlan0mon didn't make it. trying again")
-                    if not display:
-                        print(" wlan0mon didn't make it. trying again")
+                    logger.debug("wlan0mon didn't make it. trying again")
                 else:
-                    logging.debug("[Fix_Services] wlan0mon loading failed, no choice but to reboot ..")
+                    logger.debug("wlan0mon loading failed, no choice but to reboot ..")
                     agent._reboot()
 
             # exited the loop, so hopefully it loaded
@@ -342,14 +338,14 @@ class FixServices(plugins.Plugin):
                                                          "face": faces.INTENSE})
                 else:
                     print("And back on again...")
-                logging.debug("[Fix_Services] wlan0mon back up")
+                logger.debug("wlan0mon back up")
             else:
                 self.LASTTRY = time.time()
 
             time.sleep(8 + tries * 2)  # give it a bit before restarting recon in bettercap
             self.isReloadingMon = False
 
-            logging.debug("[Fix_Services] re-enable recon")
+            logger.debug("re-enable recon")
             try:
                 result = connection.run("wifi.clear; wifi.recon on")
 
@@ -359,15 +355,15 @@ class FixServices(plugins.Plugin):
                                                              "face": faces.HAPPY})
                     else:
                         print("I can see again")
-                    logging.debug("[Fix_Services] wifi.recon on")
+                    logger.debug("wifi.recon on")
                     self.LASTTRY = time.time() + 120  # 2-minute pause until next time.
                 else:
-                    logging.error("[Fix_Services] wifi.recon did not start up")
+                    logger.error("wifi.recon did not start up")
                     self.LASTTRY = time.time() - 300  # failed, so try again ASAP
                     self.isReloadingMon = False
 
             except Exception as err:
-                logging.error("[Fix_Services wifi.recon on] %s" % repr(err))
+                logger.error("[wifi.recon on] %s" % repr(err))
                 agent._reboot()
 
     # called to setup the ui elements
@@ -380,7 +376,7 @@ class FixServices(plugins.Plugin):
             else:
                 pos = (ui.width() / 2 + 35, ui.height() - 11)
 
-            logging.debug("Got here")
+            logger.debug("on_ui_setup finished")
 
     # called when the ui is updated
     def on_ui_update(self, ui):

--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -333,12 +333,10 @@ class FixServices(plugins.Plugin):
 
             # exited the loop, so hopefully it loaded
             if tries < 3:
-                if display:
-                    display.update(force=True, new_data={"status": "And back on again...",
-                                                         "face": faces.INTENSE})
-                else:
-                    print("And back on again...")
-                logger.debug("wlan0mon back up")
+                self.logPrintView("debug", "wlan0mon back up",
+                                  display, {"status": "And back on again...",
+                                            "face": faces.INTENSE},
+                                  True)
             else:
                 self.LASTTRY = time.time()
 
@@ -350,12 +348,10 @@ class FixServices(plugins.Plugin):
                 result = connection.run("wifi.clear; wifi.recon on")
 
                 if "success" in result:  # and result["success"] is True:
-                    if display:
-                        display.update(force=True, new_data={"status": "I can see again! (probably)",
-                                                             "face": faces.HAPPY})
-                    else:
-                        print("I can see again")
-                    logger.debug("wifi.recon on")
+                    self.logPrintView("debug", "wifi.recon on",
+                                      display, {"status": "I can see again! (probably)",
+                                                "face": faces.HAPPY},
+                                      True)
                     self.LASTTRY = time.time() + 120  # 2-minute pause until next time.
                 else:
                     logger.error("wifi.recon did not start up")

--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -10,6 +10,7 @@ from pwnagotchi import plugins
 from pwnagotchi.agent import Agent
 from pwnagotchi.ai.epoch import Epoch
 from pwnagotchi.ui.view import View
+from pwnagotchi.utils import StatusFile
 
 import pwnagotchi.ui.faces as faces
 from pwnagotchi.bettercap import Client
@@ -43,6 +44,8 @@ class FixServices(plugins.Plugin):
         self.isReloadingMon = False
         self.connection = None
         self.LASTTRY = 0
+        self.state = StatusFile('/etc/pwnagotchi/fix_services-state.json',
+                                data_format='json', init_data=dict())
 
     def on_loaded(self):
         """
@@ -52,8 +55,7 @@ class FixServices(plugins.Plugin):
 
     def on_ready(self, agent: Agent):
         last_lines = ''.join(list(subprocess.Popen(['journalctl', '-n10', '-k'],
-                                                   stdout=subprocess.PIPE).stdout,
-                                  text=True)[-10:])
+                                                   stdout=subprocess.PIPE, text=True).stdout)[-10:])
         try:
             cmd_output = subprocess.check_output("ip link show wlan0mon", shell=True)
             logger.debug("[ip link show wlan0mon]: %s" % repr(cmd_output))
@@ -81,26 +83,58 @@ class FixServices(plugins.Plugin):
                                                 self._tryTurningItOffAndOnAgain,
                                                 self._tryTurningItOffAndOnAgain)
 
+    def _find_in_logs(self, name, log_lines, patterns):
+        # traverse log lines starting with the newest
+        lines_to_check = log_lines[::-1]
+        
+        field_name = f'{name}_last_trigger'
+        last_matched_line = self.state.data_field_or(field_name, None)
+
+        # process only log lines newer than the `last_matched_line`
+        if last_matched_line is not None:
+            try:
+                end_index = lines_to_check.index(last_matched_line)
+                lines_to_check = lines_to_check[:end_index]
+                logger.info(f"({name}) Previous trigger {repr(last_matched_line)} found at index: {end_index}")
+            except ValueError:
+                # last matched line is no longer in the log
+                logger.info(f"({name}) Previous trigger {repr(last_matched_line)} not found in the log")
+                self.state.data[field_name] = None
+                self.state.update(self.state.data)
+
+        for line in lines_to_check:
+            for pattern, handler_callback in patterns:
+                if pattern.search(line):
+
+                    self.state.data[field_name] = line
+                    self.state.update(self.state.data)
+
+                    logger.info(f"({name}) Trigger {repr(line)} found, new state: {self.state.data}")
+
+                    handler_callback()
+                    return
+
     def on_epoch(self, agent: Agent, epoch: Epoch, epoch_data):
-        kernel_log = ''.join(list(subprocess.Popen(['journalctl', '-n10', '-k'],
-                                                   stdout=subprocess.PIPE).stdout,
-                                  text=True)[-10:])
-        sys_log = ''.join(list(subprocess.Popen(['journalctl', '-n10'],
-                                                stdout=subprocess.PIPE).stdout,
-                               text=True)[-10:])
-        pwnagotchi_log = ''.join(
-            list(subprocess.Popen(['tail', '-n10', '/etc/pwnagotchi/log/pwnagotchi.log'],
-                                  stdout=subprocess.PIPE).stdout,
-                 text=True)[-10:])
         # don't check if we ran a reset recently
         logger.debug("**** epoch")
-        if time.time() - self.LASTTRY > 180:
-            # get last 10 lines
+        if self.isReloadingMon and (time.time() - self.LASTTRY) < 180:
+            logger.debug("Duplicate attempt ignored")
+            return
+        else:
+            # get last 10 log entries
+            kernel_log = list(subprocess.Popen(['journalctl', '-n10', '-k'],
+                                            stdout=subprocess.PIPE, text=True).stdout)[-10:]
+            sys_log = list(subprocess.Popen(['journalctl', '-n10'],
+                                            stdout=subprocess.PIPE, text=True).stdout)[-10:]
+            pwnagotchi_log = list(subprocess.Popen(['tail', '-n10', '/etc/pwnagotchi/log/pwnagotchi.log'],
+                                                stdout=subprocess.PIPE, text=True).stdout)[-10:]
+
 
             display = self._get_view_if_available(agent)
 
             logger.debug("**** checking")
-            if len(self.pattern.findall(kernel_log)) >= 1:
+
+            def mon_interface_error():
                 self.logPrintView("error", "Monitor interface error. Reloading kernel modules, restarting.",
                                     display, {"status": "Monitor interface error. Reloading kernel modules, restarting.",
                                               "face": faces.COOL},
@@ -108,9 +142,8 @@ class FixServices(plugins.Plugin):
                 self._remedy_monstop(display)
                 self._remedy_monstart()
                 self._remedy_pwnagotchi_restart(agent, display)
-
-            # Look for pattern 2
-            elif len(self.pattern2.findall(sys_log)) >= 5:
+                
+            def channel_stuck():
                 logger.debug("**** Should trigger a reload of the wlan0mon device:\n%s" % kernel_log)
                 self.logPrintView("error", "Wifi channel stuck. Restarting recon.",
                                     display, {"status": "Wifi channel stuck. Restarting recon.",
@@ -118,36 +151,42 @@ class FixServices(plugins.Plugin):
                                     True)
                 self._remedy_bettercap_recon_off_on(agent, display)
 
-            # Look for pattern 3
-            elif len(self.pattern3.findall(sys_log)) >= 1:
+            def firmware_crashed():
                 self.logPrintView("debug", "Firmware has halted or crashed. Restarting wlan0mon.",
                                     display, {"status": "Firmware has halted or crashed. Restarting wlan0mon.",
                                               "face": faces.COOL},
                                     True)
                 self._remedy_monstart()
 
-            # Look for pattern 4
-            elif len(self.pattern4.findall(pwnagotchi_log)) >= 3:
+            def mon_interface_down():
                 self.logPrintView("debug", "wlan0 is down!",
                                   display, {"status": "Restarting wlan0 now!",
                                             "face": faces.COOL},
                                   True)
                 self._remedy_monstart()
 
-            # Look for pattern 5
-            elif len(self.pattern5.findall(pwnagotchi_log)) >= 1:
+            def bettercap_crashed():
                 logger.debug("Bettercap has crashed!")
                 self._remedy_pwnagotchi_restart(agent, display)
 
-            # Look for pattern 6
-            elif len(self.pattern6.findall(pwnagotchi_log)) >= 1:
-                logger.debug("Bettercap has crashed!")
-                self._remedy_pwnagotchi_restart(agent, display)
-
-            # Look for pattern 7
-            elif len(self.pattern7.findall(pwnagotchi_log)) >= 1:
+            def mon_mode_failed():
                 logger.debug("Monitor mode failed!")
                 self._remedy_bettercap_recon_off_on(agent, display)
+
+
+            if self._find_in_logs('kernel', kernel_log,
+                                  [(self.pattern, mon_interface_error)]):
+                return
+            elif self._find_in_logs('sys', sys_log,
+                                    [(self.pattern2, channel_stuck),
+                                     (self.pattern3, firmware_crashed)]):
+                return
+            elif self._find_in_logs('pwnagotchi', pwnagotchi_log,
+                                    [(self.pattern4, mon_interface_down),
+                                     (self.pattern5, bettercap_crashed),
+                                     (self.pattern6, bettercap_crashed),
+                                     (self.pattern7, mon_mode_failed)]):
+                return
             else:
                 logger.debug("logs look good")
 
@@ -194,7 +233,7 @@ class FixServices(plugins.Plugin):
 
     def logPrintView(self, level: str, message, ui=None, displayData=None, force=True):
         try:
-            lvl = logger.getLevelNamesMapping.get(level.upper())
+            lvl = logging.getLevelNamesMapping()[level.upper()]
             if lvl is None:
                 lvl = logger.ERROR
             logger.log(lvl, message)

--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -102,10 +102,14 @@ class FixServices(plugins.Plugin):
 
             logging.debug("[Fix_Services]**** checking")
             if len(self.pattern.findall(last_lines)) >= 1:
-                subprocess.check_output("monstop", shell=True)
-                subprocess.check_output("monstart", shell=True)
-                display.set('status', 'Wifi channel stuck. Restarting recon.')
+                cmd_output = subprocess.check_output("monstop", shell=True)
+                logging.debug("[Fix_Services monstop]: %s" % repr(cmd_output))
+                cmd_output = subprocess.check_output("monstart", shell=True)
+                logging.debug("[Fix_Services monstart]: %s" % repr(cmd_output))
+
+                display.set('status', 'Monitor interface error. Reloaded kernel modules, restarting.')
                 display.update(force=True)
+                logging.error('[Fix_Services] Monitor interface error. Reloaded kernel modules, restarting.')
                 agent._restart("AUTO")
 
             # Look for pattern 2
@@ -114,7 +118,7 @@ class FixServices(plugins.Plugin):
                 if hasattr(agent, 'view'):
                     display.set('status', 'Wifi channel stuck. Restarting recon.')
                     display.update(force=True)
-                logging.debug('[Fix_Services] Wifi channel stuck. Restarting recon.')
+                logging.error('[Fix_Services] Wifi channel stuck. Restarting recon.')
 
                 try:
                     result = agent.run("wifi.recon off; wifi.recon on")
@@ -193,7 +197,7 @@ class FixServices(plugins.Plugin):
                 except Exception as err:
                     logging.error("[Fix_Services wifi.recon flip] %s" % repr(err))
             else:
-                print("logs look good")
+                logging.debug("logs look good")
 
     def logPrintView(self, level, message, ui=None, displayData=None, force=True):
         try:

--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -8,6 +8,9 @@ import os
 
 import pwnagotchi
 from pwnagotchi import plugins
+from pwnagotchi.agent import Agent
+from pwnagotchi.ai.epoch import Epoch
+from pwnagotchi.ui.view import View
 
 import pwnagotchi.ui.faces as faces
 from pwnagotchi.bettercap import Client
@@ -46,7 +49,7 @@ class FixServices(plugins.Plugin):
         """
         logging.info("[Fix_Services] plugin loaded.")
 
-    def on_ready(self, agent):
+    def on_ready(self, agent: Agent):
         last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
                                                                  stdout=subprocess.PIPE).stdout))[-10:])
         try:
@@ -65,7 +68,7 @@ class FixServices(plugins.Plugin):
     # bettercap sys_log event
     # search syslog events for the brcmf channel fail, and reset when it shows up
     # apparently this only gets messages from bettercap going to syslog, not from syslog
-    def on_bcap_sys_log(self, agent, event):
+    def on_bcap_sys_log(self, agent: Agent, event):
         if re.search('wifi error while hopping to channel', event['data']['Message']):
             logging.debug("[Fix_Services]SYSLOG MATCH: %s" % event['data']['Message'])
             logging.debug("[Fix_Services]**** restarting wifi.recon")
@@ -86,7 +89,7 @@ class FixServices(plugins.Plugin):
                 logging.error("[Fix_Services]SYSLOG wifi.recon flip fail: %s" % err)
                 self._tryTurningItOffAndOnAgain(agent)
 
-    def on_epoch(self, agent, epoch, epoch_data):
+    def on_epoch(self, agent: Agent, epoch: Epoch, epoch_data):
         last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
                                                                  stdout=subprocess.PIPE).stdout))[-10:])
         other_last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10'],
@@ -98,106 +101,100 @@ class FixServices(plugins.Plugin):
         logging.debug("[Fix_Services]**** epoch")
         if time.time() - self.LASTTRY > 180:
             # get last 10 lines
-            display = agent.view()
+            if hasattr(agent, 'view'):
+                display = agent.view()
+            else:
+                display = None
 
             logging.debug("[Fix_Services]**** checking")
             if len(self.pattern.findall(last_lines)) >= 1:
-                cmd_output = subprocess.check_output("monstop", shell=True)
-                logging.debug("[Fix_Services monstop]: %s" % repr(cmd_output))
-                cmd_output = subprocess.check_output("monstart", shell=True)
-                logging.debug("[Fix_Services monstart]: %s" % repr(cmd_output))
-
-                display.set('status', 'Monitor interface error. Reloaded kernel modules, restarting.')
-                display.update(force=True)
-                logging.error('[Fix_Services] Monitor interface error. Reloaded kernel modules, restarting.')
-                agent._restart("AUTO")
+                self.logPrintView("error", "Monitor interface error. Reloading kernel modules, restarting.",
+                                    display, {"status": "Monitor interface error. Reloading kernel modules, restarting.",
+                                              "face": faces.COOL},
+                                    True)
+                self._remedy_monstop(display)
+                self._remedy_monstart()
+                self._remedy_pwnagotchi_restart(agent, display)
 
             # Look for pattern 2
             elif len(self.pattern2.findall(other_last_lines)) >= 5:
                 logging.debug("[Fix_Services]**** Should trigger a reload of the wlan0mon device:\n%s" % last_lines)
-                if hasattr(agent, 'view'):
-                    display.set('status', 'Wifi channel stuck. Restarting recon.')
-                    display.update(force=True)
-                logging.error('[Fix_Services] Wifi channel stuck. Restarting recon.')
-
-                try:
-                    result = agent.run("wifi.recon off; wifi.recon on")
-                    if result["success"]:
-                        logging.debug("[Fix_Services] wifi.recon flip: success!")
-                        if display:
-                            display.update(force=True, new_data={"status": "Wifi recon flipped!",
-                                                                 "face": faces.COOL})
-                        else:
-                            print("Wifi recon flipped\nthat was easy!")
-                    else:
-                        logging.warning("[Fix_Services] wifi.recon flip: FAILED: %s" % repr(result))
-
-                except Exception as err:
-                    logging.error("[Fix_Services wifi.recon flip] %s" % repr(err))
+                self.logPrintView("error", "Wifi channel stuck. Restarting recon.",
+                                    display, {"status": "Wifi channel stuck. Restarting recon.",
+                                              "face": faces.COOL},
+                                    True)
+                self._remedy_bettercap_recon_off_on(agent, display)
 
             # Look for pattern 3
             elif len(self.pattern3.findall(other_last_lines)) >= 1:
-                logging.debug("[Fix_Services] Firmware has halted or crashed. Restarting wlan0mon.")
-                if hasattr(agent, 'view'):
-                    display.set('status', 'Firmware has halted or crashed. Restarting wlan0mon.')
-                    display.update(force=True)
-                try:
-                    # Run the monstart command to restart wlan0mon
-                    cmd_output = subprocess.check_output("monstart", shell=True)
-                    logging.debug("[Fix_Services monstart]: %s" % repr(cmd_output))
-                except Exception as err:
-                    logging.error("[Fix_Services monstart]: %s" % repr(err))
+                self.logPrintView("debug", "Firmware has halted or crashed. Restarting wlan0mon.",
+                                    display, {"status": "Firmware has halted or crashed. Restarting wlan0mon.",
+                                              "face": faces.COOL},
+                                    True)
+                self._remedy_monstart()
 
             # Look for pattern 4
             elif len(self.pattern4.findall(other_other_last_lines)) >= 3:
-                logging.debug("[Fix_Services] wlan0 is down!")
-                if hasattr(agent, 'view'):
-                    display.set('status', 'Restarting wlan0 now!')
-                    display.update(force=True)
-                try:
-                    # Run the monstart command to restart wlan0mon
-                    cmd_output = subprocess.check_output("monstart", shell=True)
-                    logging.debug("[Fix_Services monstart]: %s" % repr(cmd_output))
-                except Exception as err:
-                    logging.error("[Fix_Services monstart]: %s" % repr(err))
+                self.logPrintView("debug", "wlan0 is down!",
+                                  display, {"status": "Restarting wlan0 now!",
+                                            "face": faces.COOL},
+                                  True)
+                self._remedy_monstart()
 
             # Look for pattern 5
             elif len(self.pattern5.findall(other_other_last_lines)) >= 1:
                 logging.debug("[Fix_Services] Bettercap has crashed!")
-                if hasattr(agent, 'view'):
-                    display.set('status', 'Restarting pwnagotchi!')
-                    display.update(force=True)
-                logging.error('[Fix_Services] restarting bettercap and pwnagotchi')
-                agent._restart("AUTO")
+                self._remedy_pwnagotchi_restart(agent, display)
 
             # Look for pattern 6
             elif len(self.pattern6.findall(other_other_last_lines)) >= 1:
                 logging.debug("[Fix_Services] Bettercap has crashed!")
-                if hasattr(agent, 'view'):
-                    display.set('status', 'Restarting pwnagotchi!')
-                    display.update(force=True)
-                logging.error('[Fix_Services] restarting bettercap and pwnagotchi')
-                agent._restart("AUTO")
+                self._remedy_pwnagotchi_restart(agent, display)
 
             # Look for pattern 7
             elif len(self.pattern7.findall(other_other_last_lines)) >= 1:
                 logging.debug("[Fix_Services] Monitor mode failed!")
-                try:
-                    result = agent.run("wifi.recon off; wifi.recon on")
-                    if result["success"]:
-                        logging.debug("[Fix_Services] wifi.recon flip: success!")
-                        if display:
-                            display.update(force=True, new_data={"status": "Wifi recon flipped!",
-                                                                 "face": faces.COOL})
-                        else:
-                            print("Wifi recon flipped\nthat was easy!")
-                    else:
-                        logging.warning("[Fix_Services] wifi.recon flip: FAILED: %s" % repr(result))
-
-                except Exception as err:
-                    logging.error("[Fix_Services wifi.recon flip] %s" % repr(err))
+                self._remedy_bettercap_recon_off_on(agent, display)
             else:
                 logging.debug("logs look good")
+
+    def _remedy_monstop(self, display: View):
+        try:
+            cmd_output = subprocess.check_output("monstop", shell=True)
+            self.logPrintView("info", "[Fix_Services] wlan0mon down and deleted: %s" % repr(cmd_output),
+                                display, {"status": "wlan0mon d-d-d-down!", "face": faces.BORED})
+        except Exception as nope:
+            logging.error("[Fix_Services delete wlan0mon] %s" % repr(nope))
+
+    def _remedy_monstart(self):
+        try:
+            # Run the monstart command to restart wlan0mon
+            cmd_output = subprocess.check_output("monstart", shell=True)
+            logging.debug("[Fix_Services monstart]: %s" % repr(cmd_output))
+        except Exception as err:
+            logging.error("[Fix_Services monstart]: %s" % repr(err))
+
+    def _remedy_pwnagotchi_restart(self, agent: Agent, display: View):
+        self.logPrintView("error", "restarting bettercap and pwnagotchi",
+                                    display, {"status": "Restarting pwnagotchi!",
+                                              "face": faces.COOL},
+                                    True)
+        agent._restart("AUTO")
+
+    def _remedy_bettercap_recon_off_on(self, agent: Client, display: View):
+        try:
+            result = agent.run("wifi.recon off; wifi.recon on")
+            if result["success"]:
+                logging.debug("[Fix_Services] wifi.recon flip: success!")
+                self.logPrintView("debug", "wifi.recon flip: success!",
+                                    display, {"status": "Wifi recon flipped!",
+                                              "face": faces.COOL},
+                                    True)
+            else:
+                logging.warning("[Fix_Services] wifi.recon flip: FAILED: %s" % repr(result))
+
+        except Exception as err:
+            logging.error("[Fix_Services wifi.recon flip] %s" % repr(err))
 
     def logPrintView(self, level, message, ui=None, displayData=None, force=True):
         try:
@@ -273,13 +270,7 @@ class FixServices(plugins.Plugin):
 
             logging.debug("[Fix_Services] recon paused. Now trying wlan0mon reload")
 
-            try:
-                cmd_output = subprocess.check_output("monstop", shell=True)
-                self.logPrintView("info", "[Fix_Services] wlan0mon down and deleted: %s" % cmd_output,
-                                  display, {"status": "wlan0mon d-d-d-down!", "face": faces.BORED})
-            except Exception as nope:
-                logging.error("[Fix_Services delete wlan0mon] %s" % nope)
-                pass
+            self._remedy_monstop(display)
 
             logging.debug("[Fix_Services] Now trying modprobe -r")
 

--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -74,22 +74,12 @@ class FixServices(plugins.Plugin):
         if re.search('wifi error while hopping to channel', event['data']['Message']):
             logger.debug("SYSLOG MATCH: %s" % event['data']['Message'])
             logger.debug("**** restarting wifi.recon")
-            try:
-                result = agent.run("wifi.recon off; wifi.recon on")
-                if result["success"]:
-                    logger.debug("wifi.recon flip: success!")
-                    if hasattr(agent, 'view'):
-                        display = agent.view()
-                        if display:
-                            display.update(force=True, new_data={"status": "Wifi recon flipped!", "face": faces.COOL})
-                    else:
-                        print("Wifi recon flipped")
-                else:
-                    logger.warning("wifi.recon flip: FAILED: %s" % repr(result))
-                    self._tryTurningItOffAndOnAgain(agent)
-            except Exception as err:
-                logger.error("SYSLOG wifi.recon flip fail: %s" % err)
-                self._tryTurningItOffAndOnAgain(agent)
+
+            display = self._get_view_if_available(agent)
+
+            self._remedy_bettercap_recon_off_on(agent, display,
+                                                self._tryTurningItOffAndOnAgain,
+                                                self._tryTurningItOffAndOnAgain)
 
     def on_epoch(self, agent: Agent, epoch: Epoch, epoch_data):
         last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
@@ -103,10 +93,8 @@ class FixServices(plugins.Plugin):
         logger.debug("**** epoch")
         if time.time() - self.LASTTRY > 180:
             # get last 10 lines
-            if hasattr(agent, 'view'):
-                display = agent.view()
-            else:
-                display = None
+
+            display = self._get_view_if_available(agent)
 
             logger.debug("**** checking")
             if len(self.pattern.findall(last_lines)) >= 1:
@@ -183,7 +171,7 @@ class FixServices(plugins.Plugin):
                                     True)
         agent._restart("AUTO")
 
-    def _remedy_bettercap_recon_off_on(self, agent: Client, display: View):
+    def _remedy_bettercap_recon_off_on(self, agent: Client, display: View, fail_callback=None, exc_callback=None):
         try:
             result = agent.run("wifi.recon off; wifi.recon on")
             if result["success"]:
@@ -194,9 +182,12 @@ class FixServices(plugins.Plugin):
                                     True)
             else:
                 logger.warning("wifi.recon flip: FAILED: %s" % repr(result))
-
+                if fail_callback != None:
+                    fail_callback(agent)
         except Exception as err:
-            logger.error("[wifi.recon flip] %s" % repr(err))
+            logger.error("[wifi.recon flip fail] %s" % repr(err))
+            if exc_callback != None:
+                exc_callback(agent)
 
     def logPrintView(self, level: str, message, ui=None, displayData=None, force=True):
         try:
@@ -213,6 +204,12 @@ class FixServices(plugins.Plugin):
                 print("[%s] %s" % (level, message))
         except Exception as err:
             logger.error("[logPrintView] ERROR %s" % repr(err))
+            
+    def _get_view_if_available(self, agent):
+        display = None
+        if hasattr(agent, 'view'):
+            display = agent.view()
+        return display
 
     def _tryTurningItOffAndOnAgain(self, connection):
         # avoid overlapping restarts, but allow it if it's been a while
@@ -223,13 +220,10 @@ class FixServices(plugins.Plugin):
             self.isReloadingMon = True
             self.LASTTRY = time.time()
 
-            if hasattr(connection, 'view'):
-                display = connection.view()
-                if display:
-                    display.update(force=True, new_data={"status": "I'm blind! Try turning it off and on again",
-                                                         "face": faces.BORED})
-            else:
-                display = None
+            display = self._get_view_if_available(connection)
+            if display:
+                display.update(force=True, new_data={"status": "I'm blind! Try turning it off and on again",
+                                                        "face": faces.BORED})
 
             # main divergence from WATCHDOG starts here
             #

--- a/pwnagotchi/plugins/default/fix_services.py
+++ b/pwnagotchi/plugins/default/fix_services.py
@@ -72,7 +72,7 @@ class FixServices(plugins.Plugin):
     # apparently this only gets messages from bettercap going to syslog, not from syslog
     def on_bcap_sys_log(self, agent: Agent, event):
         if re.search('wifi error while hopping to channel', event['data']['Message']):
-            logger.debug("SYSLOG MATCH: %s" % event['data']['Message'])
+            logger.debug("bettercap sys.log MATCH: %s" % event['data']['Message'])
             logger.debug("**** restarting wifi.recon")
 
             display = self._get_view_if_available(agent)
@@ -82,11 +82,11 @@ class FixServices(plugins.Plugin):
                                                 self._tryTurningItOffAndOnAgain)
 
     def on_epoch(self, agent: Agent, epoch: Epoch, epoch_data):
-        last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
+        kernel_log = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10', '-k'],
                                                                  stdout=subprocess.PIPE).stdout))[-10:])
-        other_last_lines = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10'],
+        sys_log = ''.join(list(TextIOWrapper(subprocess.Popen(['journalctl', '-n10'],
                                                                        stdout=subprocess.PIPE).stdout))[-10:])
-        other_other_last_lines = ''.join(
+        pwnagotchi_log = ''.join(
             list(TextIOWrapper(subprocess.Popen(['tail', '-n10', '/etc/pwnagotchi/log/pwnagotchi.log'],
                                                 stdout=subprocess.PIPE).stdout))[-10:])
         # don't check if we ran a reset recently
@@ -97,7 +97,7 @@ class FixServices(plugins.Plugin):
             display = self._get_view_if_available(agent)
 
             logger.debug("**** checking")
-            if len(self.pattern.findall(last_lines)) >= 1:
+            if len(self.pattern.findall(kernel_log)) >= 1:
                 self.logPrintView("error", "Monitor interface error. Reloading kernel modules, restarting.",
                                     display, {"status": "Monitor interface error. Reloading kernel modules, restarting.",
                                               "face": faces.COOL},
@@ -107,8 +107,8 @@ class FixServices(plugins.Plugin):
                 self._remedy_pwnagotchi_restart(agent, display)
 
             # Look for pattern 2
-            elif len(self.pattern2.findall(other_last_lines)) >= 5:
-                logger.debug("**** Should trigger a reload of the wlan0mon device:\n%s" % last_lines)
+            elif len(self.pattern2.findall(sys_log)) >= 5:
+                logger.debug("**** Should trigger a reload of the wlan0mon device:\n%s" % kernel_log)
                 self.logPrintView("error", "Wifi channel stuck. Restarting recon.",
                                     display, {"status": "Wifi channel stuck. Restarting recon.",
                                               "face": faces.COOL},
@@ -116,7 +116,7 @@ class FixServices(plugins.Plugin):
                 self._remedy_bettercap_recon_off_on(agent, display)
 
             # Look for pattern 3
-            elif len(self.pattern3.findall(other_last_lines)) >= 1:
+            elif len(self.pattern3.findall(sys_log)) >= 1:
                 self.logPrintView("debug", "Firmware has halted or crashed. Restarting wlan0mon.",
                                     display, {"status": "Firmware has halted or crashed. Restarting wlan0mon.",
                                               "face": faces.COOL},
@@ -124,7 +124,7 @@ class FixServices(plugins.Plugin):
                 self._remedy_monstart()
 
             # Look for pattern 4
-            elif len(self.pattern4.findall(other_other_last_lines)) >= 3:
+            elif len(self.pattern4.findall(pwnagotchi_log)) >= 3:
                 self.logPrintView("debug", "wlan0 is down!",
                                   display, {"status": "Restarting wlan0 now!",
                                             "face": faces.COOL},
@@ -132,17 +132,17 @@ class FixServices(plugins.Plugin):
                 self._remedy_monstart()
 
             # Look for pattern 5
-            elif len(self.pattern5.findall(other_other_last_lines)) >= 1:
+            elif len(self.pattern5.findall(pwnagotchi_log)) >= 1:
                 logger.debug("Bettercap has crashed!")
                 self._remedy_pwnagotchi_restart(agent, display)
 
             # Look for pattern 6
-            elif len(self.pattern6.findall(other_other_last_lines)) >= 1:
+            elif len(self.pattern6.findall(pwnagotchi_log)) >= 1:
                 logger.debug("Bettercap has crashed!")
                 self._remedy_pwnagotchi_restart(agent, display)
 
             # Look for pattern 7
-            elif len(self.pattern7.findall(other_other_last_lines)) >= 1:
+            elif len(self.pattern7.findall(pwnagotchi_log)) >= 1:
                 logger.debug("Monitor mode failed!")
                 self._remedy_bettercap_recon_off_on(agent, display)
             else:

--- a/pwnagotchi/utils.py
+++ b/pwnagotchi/utils.py
@@ -667,11 +667,11 @@ def extract_from_pcap(path, fields):
 
 
 class StatusFile(object):
-    def __init__(self, path, data_format='raw'):
+    def __init__(self, path, data_format='raw', init_data=None):
         self._path = path
         self._updated = None
         self._format = data_format
-        self.data = None
+        self.data = init_data
 
         if os.path.exists(path):
             self._updated = datetime.fromtimestamp(os.path.getmtime(path))


### PR DESCRIPTION
An ongoing project to get `fix_services` plugin to a more maintainable and better working state. Tested stable.

Most notably:
* Persist last trigger to avoid triggering on it immediately after restart remedy
* Remove some of the repeating boilerplate